### PR TITLE
Add ioBroker auth via dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+IOBROKER_USER=dotenvuser
+IOBROKER_PASSWORD=dotenvpass

--- a/tests/test_weathercloud_receiver.py
+++ b/tests/test_weathercloud_receiver.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import importlib
+import weathercloud_receiver
+
+class TestSendToIoBroker(unittest.TestCase):
+    def reload_module(self):
+        return importlib.reload(weathercloud_receiver)
+
+    def test_send_to_iobroker_with_auth(self):
+        with patch.dict(os.environ, {'IOBROKER_USER': 'admin', 'IOBROKER_PASSWORD': 'secret'}, clear=True):
+            module = self.reload_module()
+            with patch('weathercloud_receiver.requests.get') as mock_get:
+                mock_response = MagicMock(status_code=200)
+                mock_get.return_value = mock_response
+
+                module.send_to_iobroker('5')
+
+                expected_url = 'http://localhost:8087/set/javascript.0.Wetterstation.Weathercloud_Regenrate?value=5&ack=true&user=admin&pass=secret'
+                mock_get.assert_called_with(expected_url, timeout=10)
+
+    def test_send_to_iobroker_from_dotenv(self):
+        with patch.dict(os.environ, {}, clear=True):
+            module = self.reload_module()
+            with patch('weathercloud_receiver.requests.get') as mock_get:
+                mock_response = MagicMock(status_code=200)
+                mock_get.return_value = mock_response
+
+                module.send_to_iobroker('10')
+
+                expected_url = 'http://localhost:8087/set/javascript.0.Wetterstation.Weathercloud_Regenrate?value=10&ack=true&user=dotenvuser&pass=dotenvpass'
+                mock_get.assert_called_with(expected_url, timeout=10)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/weathercloud_receiver.py
+++ b/weathercloud_receiver.py
@@ -4,7 +4,11 @@ import logging
 import time
 import sys
 import threading
+import os
+from dotenv import load_dotenv
 from send_api_weathercloud_net import resolve_hostname, send_weathercloud
+
+load_dotenv()
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', stream=sys.stdout)
 
@@ -26,7 +30,12 @@ def extract_rainrate(data):
 def send_to_iobroker(rainrate, max_retries=10):
     adapter_url = 'http://localhost:8087'
     state_id = 'javascript.0.Wetterstation.Weathercloud_Regenrate'
-    url = f"{adapter_url}/set/{state_id}?value={rainrate}&ack=true"
+
+    user = os.getenv('IOBROKER_USER')
+    password = os.getenv('IOBROKER_PASSWORD')
+
+    auth_params = f"&user={user}&pass={password}" if user and password else ''
+    url = f"{adapter_url}/set/{state_id}?value={rainrate}&ack=true{auth_params}"
 
     for _ in range(max_retries):
         try:
@@ -89,4 +98,5 @@ def start_server():
             if client_socket is not None:
                 client_socket.close()
 
-start_server()
+if __name__ == "__main__":
+    start_server()


### PR DESCRIPTION
## Summary
- load credentials from `.env` using `python-dotenv`
- ensure tests reload module and verify `.env` behaviour
- provide example `.env` file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68469822c1dc832aa504790109a16d2e